### PR TITLE
Fix book search by title

### DIFF
--- a/src/main/java/one/microstream/demo/bookstore/data/Books.java
+++ b/src/main/java/one/microstream/demo/bookstore/data/Books.java
@@ -15,9 +15,7 @@ import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
-import org.apache.lucene.util.QueryBuilder;
 
 import one.microstream.demo.bookstore.BookStoreDemo;
 import one.microstream.demo.bookstore.data.Index.DocumentPopulator;

--- a/src/main/java/one/microstream/demo/bookstore/data/Books.java
+++ b/src/main/java/one/microstream/demo/bookstore/data/Books.java
@@ -14,7 +14,9 @@ import java.util.stream.Stream;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.QueryBuilder;
 
 import one.microstream.demo.bookstore.BookStoreDemo;
@@ -457,9 +459,9 @@ public class Books extends ReadWriteLocked
 
 	/**
 	 * Searches all books by title with a given query.
-	 * The query can contain following wildcard characters:<br>
-	 * * placeholder for multiple characters<br>
-	 * ? placeholder for a single character
+	 *
+	 * <p>Internally, this method wraps the given query string with a leading and a trailing {@code
+	 * .*} and uses the {@link RegexpQuery} to mimic the SQL {@code LIKE} term.
 	 *
 	 * @param queryText the search query
 	 * @return a list of books matching the query, or an empty list
@@ -467,8 +469,7 @@ public class Books extends ReadWriteLocked
 	public List<Book> searchByTitle(final String queryText)
 	{
 		final Index<Book>  index        = this.ensureIndex();
-		final QueryBuilder queryBuilder = index.createQueryBuilder();
-		final Query        query        = queryBuilder.createPhraseQuery("title", queryText);
+		final RegexpQuery query = new RegexpQuery(new Term("title", ".*" + queryText + ".*"));
 		return index.search(query, Integer.MAX_VALUE);
 	}
 

--- a/src/main/java/one/microstream/demo/bookstore/jpa/dal/BookRepository.java
+++ b/src/main/java/one/microstream/demo/bookstore/jpa/dal/BookRepository.java
@@ -20,7 +20,7 @@ public interface BookRepository extends BaseRepository<BookEntity>
 		String title
 	);
 
-	public List<BookEntity> findByTitleLikeAndAuthorAddressCityStateCountry(
+	public List<BookEntity> findByTitleContainingIgnoreCaseAndAuthorAddressCityStateCountry(
 		String title,
 		CountryEntity country
 	);

--- a/src/main/java/one/microstream/demo/bookstore/ui/Query.java
+++ b/src/main/java/one/microstream/demo/bookstore/ui/Query.java
@@ -198,7 +198,7 @@ class Query
 									.filter(book -> book.author().address().city().state().country() == country)
 									.collect(toList()),
 								() -> repositories.bookRepository()
-									.findByTitleLikeAndAuthorAddressCityStateCountry(pattern, countryEntity)
+									.findByTitleContainingIgnoreCaseAndAuthorAddressCityStateCountry(pattern, countryEntity)
 							))
 						)
 					)


### PR DESCRIPTION
As far as I can tell, the *BooksByTitle* query never returns any results for the JPA- implementation, as the repository method used for this query does not work with the search string provided (using the *LIKE* keyword means one would have to provide *"%TERM%"*, see this [Baeldung page](https://www.baeldung.com/spring-jpa-like-queries#1-containing-contains-iscontaining-and-like)).
Aside from this, using an alternative repo method would only enable checking the JPA-based book titles for *contains*, but not full words. The MicroStream-based implementation on the other hand uses a word-based search, which is quite different from the contains.

This pull request addresses the issues described above by:

- **Fix broken JPA repo method**: The original implementation expected a search term of format "%TERM%", which was never provided; the new  implementation of the method does not expect this and furthermore is  case insensitive to match the equivalent MicroStream implementation.
- **Make MicroStream book title search more similar to JPA**: The original  implementation of this title search was only looking for words  matching the given query string, but not parts of words (e.g. 'the'  would never match 'nither'), while JPA is using LIKE, meaning as long  as the title contains the given term, a match is generated. For  MicroStream, this was implemented by instead of using a PhraseQuery,  a RegexpQuery was used.
